### PR TITLE
キーイベント処理を KeyEventKind::Press のみに制限する

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 use crate::poll::StatsReceiver;
 use crate::stats::{format_u64, Stats};
 use crate::Options;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 use orfail::OrFail;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
@@ -66,6 +66,9 @@ impl App {
 
     fn handle_key_event(&mut self, key: KeyEvent) -> orfail::Result<bool> {
         if let Some(editing) = &mut self.ui.editing_stats_key_filter {
+            if key.kind != KeyEventKind::Press {
+                return Ok(false);
+            }
             let mut consumed = false;
             let mut finished = false;
             match key.code {


### PR DESCRIPTION
fix: #9

- KeyEventKind が Press ではない場合に早期リターンするようにしました

---

This pull request includes changes to the `src/ui.rs` file to handle different kinds of key events more effectively. The most important changes include the addition of `KeyEventKind` to the imports and the modification of the `handle_key_event` function to handle only key press events.

Improvements to key event handling:

* [`src/ui.rs`](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L4-R4): Added `KeyEventKind` to the imports to handle different types of key events.
* [`src/ui.rs`](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626R69-R71): Modified the `handle_key_event` function to return early if the key event kind is not a press, ensuring that only key press events are processed.